### PR TITLE
Add external solving server to make queries deterministic

### DIFF
--- a/program.py
+++ b/program.py
@@ -6,6 +6,8 @@ from bit_vector_tests import bv
 import itertools
 import operator
 
+from solver import solver
+
 class Program:
     def __init__(self, prog_name='', num_prog_inputs=1, components=[]):
         self.prog_name = prog_name
@@ -102,7 +104,7 @@ class Program:
         constraints.append(dist_output != dist_output2)
         constraints += self.behave_constraints(list_inputs_outputs + [(dist_input, dist_output)], False, num_lines_to_ignore_at_end)
 
-        name = f'{self.prog_name}d_'
+        name = f'p{self.prog_name}d_'
         p = Program(name, self.I_size, self.components)
         constraints += p.behave_constraints(list_inputs_outputs + [(dist_input, dist_output2)], True)
         return constraints
@@ -118,13 +120,13 @@ class Program:
         constraints = []
         self.update_values_based_on_components()
         for j, (inputs, output) in enumerate(list_inputs_outputs):
-            name = f'{self.prog_name}{j}_'
+            name = f'p{self.prog_name}{j}_'
             p = Program(name, self.I_size, self.components)
             constraints += p.generate_constraints(inputs, output, distinctl, num_lines_to_ignore_at_end)
         return constraints
 
     def solve_constraints(self, constraints, timeout=10000000):
-        s = Solver()
+        s = solver.Solver()
         s.set('timeout', timeout)
         s.add(constraints)
         check = s.check()

--- a/solver/server.py
+++ b/solver/server.py
@@ -1,0 +1,59 @@
+import sys
+import z3
+
+from solver_utils import write_cmd, read_cmd
+
+
+class Server(object):
+    def __init__(self):
+        self._s = z3.Solver()
+
+    def _write(self, command):
+        return write_cmd(sys.stdout.buffer, command)
+
+    def _read(self):
+        return read_cmd(sys.stdin)
+
+    def run(self):
+        while True:
+            self.handle_cmd()
+
+    def handle_cmd(self):
+        cmd = self._read()
+        if not cmd:
+            sys.exit(0)
+        try:
+            self._write({'return': getattr(self, cmd['name'])(*cmd['args'], **cmd['kwargs'])})
+        except Exception as e:
+            self._write({'exc': repr(e)})
+
+    def add(self, term):
+        self._s.add(z3.parse_smt2_string(term))
+
+    def set(self, **kwargs):
+        self._s.set(**{str(k): v for k, v in kwargs.items()})
+
+    def check(self):
+        return str(self._s.check())
+
+    def push(self):
+        return str(self._s.push())
+
+    def pop(self):
+        return str(self._s.pop())
+
+    def model(self):
+        return str(self._s.model())
+
+    def model_evaluate(self, term):
+        model = self._s.model()
+
+        for t in model.decls():
+            if str(t) == term:
+                term = t()
+                break
+        return str(self._s.model().evaluate(term))
+
+
+if __name__ == '__main__':
+    Server().run()

--- a/solver/solver.py
+++ b/solver/solver.py
@@ -1,0 +1,94 @@
+import subprocess
+import os
+
+import z3
+import solver.solver_utils as sutils
+
+
+CURRENT = os.path.dirname(os.path.realpath(__file__))
+Z3_SERVER_FILE = os.path.join(CURRENT, "server.py")
+
+
+def to_smt2(*terms):
+    s = z3.Solver()
+    s.add(*terms)
+    return s.to_smt2()
+
+
+class ModelProxy(object):
+    def __init__(self, model_str, solver):
+        self._model = model_str
+        self._solver = solver
+
+    def __str__(self):
+        return self._model
+
+    def __repr__(self):
+        return self._model
+
+    def evaluate(self, term):
+        term = term.sexpr()
+        return self._solver._call('model_evaluate', term)
+
+    def eval(self, term):
+        return self.evaluate(term)
+    
+    def __getitem__(self, term):
+        return self.evaluate(term)
+
+
+class Solver(object):
+    def __init__(self):
+        self._proc = subprocess.Popen(['python3', Z3_SERVER_FILE],
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                # stderr=subprocess.PIPE,
+                )
+
+    def _write(self, command):
+        sutils.write_cmd(self._proc.stdin, command)
+
+    def _call(self, name, *args, **kwargs):
+        self._write({'name': name, 'args': args, 'kwargs': kwargs})
+        res = self._read()
+        if 'return' in res:
+            return res['return']
+        if 'exc' in res:
+            raise RuntimeError(res['exc'])
+
+    def _read(self, **kwargs):
+        return sutils.read_cmd(self._proc.stdout)
+
+    def add(self, *terms):
+        term = to_smt2(*terms)
+        return self._call('add', term)
+
+    def set(self, *args, **kwargs):
+        for i in range(0, len(args), 2):
+            kwargs[args[i]] = args[i+1]
+        return self._call('set', **kwargs)
+
+    def check(self):
+        vals = {'sat': z3.sat, 'unsat': z3.unsat, 'unknown': z3.unknown}
+        return vals.get(self._call('check'))
+
+    def model(self):
+        return ModelProxy(self._call('model'), self)
+
+    def push(self):
+        return self._call('push')
+
+    def pop(self):
+        return self._call('pop')
+
+
+if __name__ == '__main__':
+    x = z3.BitVec('x', 32)
+    y = z3.BitVec('y', 32)
+    s = Solver()
+    s.add(x == y)
+    print(s.check())
+    model = s.model()
+    print(model)
+    print(model.evaluate(x))
+    # print(s.model().evaluate(x))

--- a/solver/solver_utils.py
+++ b/solver/solver_utils.py
@@ -1,0 +1,29 @@
+import math
+import json
+import sys
+
+LEN_LEN = 8
+
+def write_cmd(stream, command):
+    payload = str.encode(json.dumps(command))
+    assert math.log(len(payload), 10) < LEN_LEN, "payload length = {} to large".format(len(payload))
+    stream.write(str.encode(str(len(payload))).rjust(LEN_LEN, b'0'))
+    stream.write(payload)
+    stream.flush()
+
+
+def read(stream, count):
+    v = stream.read(count)
+    return v
+
+
+def read_cmd(stream):
+    cmdlen = read(stream, LEN_LEN)
+    if not cmdlen:
+        return None
+    data = read(stream, int(cmdlen))
+    try:
+        return json.loads(data)
+    except Exception as e:
+        print(data)
+        raise e


### PR DESCRIPTION
Z3py queries become non-deterministic because some internal state is
retained even across runs. This change makes `Solver()` spawn a new
process and sends all the solver calls to that process instead. This
way, each time we run a query we start from an identical initial state.

Two caveats:
1. I haven't tested what happens if the timeout is hit
2. I don't have a Windows machine so haven't tested there; it's possible
   the code to spawn a new server (`Solver.__init__`) might need to
   change a little for Windows

(The code here is borrowed from https://github.com/uw-unsat/yggdrasil)